### PR TITLE
Devel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Janak Panthi UT NRG
+Copyright (c) 2024, Janak Panthi, UT NRG
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/affordance_util/include/affordance_util/affordance_util.hpp
+++ b/affordance_util/include/affordance_util/affordance_util.hpp
@@ -293,13 +293,15 @@ std::vector<double> compute_gripper_joint_trajectory(const GripperGoalType &grip
  * robot palm homogeneous transformation matrix, and current joint states
  * @param aff ScrewInfo containing information about affordance
  * @param approach_end_pose Eigen::MatrixXd representing the approach motion end pose HTM
+ * @param approach_gamma double specifying the weight of the rotational motion relative to the translational motion along the approach trajectory.
+ * Default is 1.0, i.e. rotational and translational motion are weighted equally.
  * @param vir_screw_order affordance_util::VirtualScrewOrder indicating the order for the virtual EE screws. Possible
  * values are "xyz", "yzx" "zxy", and "none". Default is "xyz"
  *
  * @return affordance_util::CcModel containing the closed-chain affordance screws and approach limit.
  */
 CcModel compose_cc_model_slist(const RobotDescription &robot_description, const ScrewInfo &aff_info,
-                               const Eigen::MatrixXd &approach_end_pose,
+                               const Eigen::MatrixXd &approach_end_pose, const double approach_gamma = 1.0,
                                const VirtualScrewOrder &vir_screw_order = VirtualScrewOrder::XYZ);
 /**
  * @brief Given a robot description, affordance information, and order of virtual screws, returns the closed-chain

--- a/affordance_util/include/affordance_util/affordance_util.hpp
+++ b/affordance_util/include/affordance_util/affordance_util.hpp
@@ -3,31 +3,6 @@
 //      Project   : affordance_util
 //      Created   : Fall 2023
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 /*
    Credits: Some functions are translated to Cpp from Kevin Lynch's Modern

--- a/affordance_util/src/affordance_util/affordance_util.cpp
+++ b/affordance_util/src/affordance_util/affordance_util.cpp
@@ -63,14 +63,14 @@ std::vector<double> compute_gripper_joint_trajectory(const GripperGoalType &grip
 }
 
 CcModel compose_cc_model_slist(const RobotDescription &robot_description, const ScrewInfo &aff_info,
-                               const Eigen::MatrixXd &approach_end_pose, const VirtualScrewOrder &vir_screw_order)
+                               const Eigen::MatrixXd &approach_end_pose, const double approach_gamma, const VirtualScrewOrder &vir_screw_order)
 {
     CcModel cc_model; // Output of the function
 
     // Compute robot Jacobian
     const Eigen::MatrixXd robot_jacobian = JacobianSpace(robot_description.slist, robot_description.joint_states);
 
-    // Compute approach screw
+    // Compute approach twist
     const Eigen::Matrix4d approach_start_pose =
         FKinSpace(robot_description.M, robot_description.slist, robot_description.joint_states);
     const Eigen::Vector3d ee_location = approach_start_pose.block<3, 1>(0, 3); // Translation part of the HTM
@@ -78,10 +78,24 @@ CcModel compose_cc_model_slist(const RobotDescription &robot_description, const 
         affordance_util::Adjoint(approach_start_pose) *
         affordance_util::se3ToVec(
             affordance_util::MatrixLog6(affordance_util::TransInv(approach_start_pose) * approach_end_pose));
-    const Eigen::Matrix<double, 6, 1> approach_screw = approach_twist / approach_twist.norm();
+
+    // Compute approach magnitude
+    const Eigen::Vector3d approach_twist_w = approach_twist.head<3>();
+    const Eigen::Vector3d approach_twist_v = approach_twist.tail<3>();
+    double approach_magnitude = std::sqrt(approach_gamma * approach_gamma * approach_twist_w.squaredNorm() + approach_twist_v.squaredNorm());
+
+    // Compute approach screw -- avoid division by zero
+    Eigen::Matrix<double, 6, 1> approach_screw;
+    const double epsilon = 1e-6; // Threshold for considering approach magnitude to be effectively zero
+    if (approach_magnitude < epsilon) {
+        approach_magnitude = 0.0; // Set approach magnitude to exactly zero to avoid numerical issues
+        approach_screw << 0, 0, 1, 0, 0, 0; // Default screw (arbitrary, only used when motion magnitude is zero)
+    } else {
+        approach_screw = approach_twist / approach_magnitude;
+    }
 
     // Fill out the approach limit
-    cc_model.approach_limit = approach_twist.norm();
+    cc_model.approach_limit = approach_magnitude;
 
     // If aff info says to extract location from FK, do that
     ScrewInfo aff = aff_info;

--- a/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner.hpp
+++ b/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner.hpp
@@ -3,31 +3,6 @@
 //      Project   : cc_affordance_planner
 //      Created   : Fall 2023
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CC_AFFORDANCE_PLANNER

--- a/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner.hpp
+++ b/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner.hpp
@@ -96,6 +96,7 @@ struct TaskDescription
     affordance_util::ScrewInfo affordance_info;
     Goal goal;
     int trajectory_density = 10;
+    double approach_gamma = 1.0; // m/rad, weighs rotational motion relative to translational motion along the approach trajectory
     MotionType motion_type = MotionType::AFFORDANCE;
     affordance_util::VirtualScrewOrder vir_screw_order = affordance_util::VirtualScrewOrder::XYZ;
     affordance_util::GripperGoalType gripper_goal_type = affordance_util::GripperGoalType::CONSTANT;

--- a/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner_interface.hpp
+++ b/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner_interface.hpp
@@ -3,31 +3,6 @@
 //      Project   : cc_affordance_planner
 //      Created   : Fall 2024
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CC_AFFORDANCE_PLANNER_INTERFACE

--- a/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner_util.hpp
+++ b/cc_affordance_planner/include/cc_affordance_planner/cc_affordance_planner_util.hpp
@@ -3,31 +3,6 @@
 //      Project   : cc_affordance_planner
 //      Created   : Fall 2023
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CC_AFFORDANCE_PLANNER_UTIL

--- a/cc_affordance_planner/src/cc_affordance_planner/cc_affordance_planner_interface.cpp
+++ b/cc_affordance_planner/src/cc_affordance_planner/cc_affordance_planner_interface.cpp
@@ -87,7 +87,7 @@ PlannerResult CcAffordancePlannerInterface::generate_joint_trajectory(
 
         // Compose the closed-chain model screws and determine the limit for the approach screw
         const affordance_util::CcModel cc_model =
-            affordance_util::compose_cc_model_slist(robot_description, aff, canonical_pose, vir_screw_order);
+            affordance_util::compose_cc_model_slist(robot_description, aff, canonical_pose, task_description.approach_gamma, vir_screw_order);
 
         // Extract and construct the secondary joint goals
         nof_secondary_joints += 1; // add approach joint


### PR DESCRIPTION
This pull request introduces a new parameter, `approach_gamma`, which allows users to control the weighting between rotational and translational motion in the approach trajectory for closed-chain affordance modeling. 

Key changes include:

* Added the `approach_gamma` parameter to `compose_cc_model_slist` in both its declaration and implementation, allowing users to specify the relative weight of rotational versus translational motion in the approach trajectory. The default is 1.0, meaning equal weighting. The computation of the approach screw and its magnitude now properly incorporates this parameter, enabling tuning of this design parameter. [[1]](diffhunk://#diff-e63cec95899761ee2cbdf2a7adb2cbf2fa967b4b8b61a27415f8accf02753f4dR271-R279) [[2]](diffhunk://#diff-47e107835ebab2489bd3b98eee8a943d631a4db3041a78367a143cfadc32d0abL66-R98)
* Updated the `TaskDescription` struct in `cc_affordance_planner.hpp` to include the `approach_gamma` field, enabling it to be set per task.
* Modified the call to `compose_cc_model_slist` in `CcAffordancePlannerInterface::generate_joint_trajectory` to pass the `approach_gamma` from the task description, ensuring the new parameter is used throughout the planning pipeline.